### PR TITLE
Update Jenkinsfile to include it's name

### DIFF
--- a/JenkinsfileNext
+++ b/JenkinsfileNext
@@ -1,5 +1,6 @@
 @Library(value='kids-first/aws-infra-jenkins-shared-libraries', changelog=false) _
 ecs_service_type_1_standard {
+    jenkinsfile_name  = "JenkinsfileNext"
     projectName = "kf-key-manager-next"
     internal_app = "false"
     environments = "prd"


### PR DESCRIPTION
Description
------------

Jenkinsfile is not aware of it's own name, therefore, you have to specify which file you would like to use. I added jenkinsfile_name  = "JenkinsfileNext" to fix that.