### PR TITLE
feat: SKFP-884 duplicate key manager in QA

### DIFF
--- a/JenkinsfileNext
+++ b/JenkinsfileNext
@@ -3,7 +3,7 @@ ecs_service_type_1_standard {
     jenkinsfile_name  = "JenkinsfileNext"
     projectName = "kf-key-manager-next"
     internal_app = "false"
-    environments = "prd"
+    environments = "qa,prd"
     docker_image_type = "debian"
     dependencies = "ecr"
     create_default_iam_role = "0"


### PR DESCRIPTION
Need to deploy another key-manager for QA next (we can't just change the configs of the existing one because it would break QA legacy)